### PR TITLE
Update pom.xml so it builds 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,14 @@
     </plugins>
   </build>
 
+
+  <repositories>
+  	<repository>
+		<id>jitpack.io</id>
+		<url>https://jitpack.io</url>
+	</repository>
+  </repositories>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -153,9 +161,9 @@
       <version>2.0.0</version>
     </dependency>
     <dependency>
-      <groupId>vavi</groupId> <!-- com.github.umjammer -->
+      <groupId>com.github.umjammer</groupId> <!-- com.github.umjammer -->
       <artifactId>vavi-commons</artifactId>
-      <version>1.1.7-SNAPSHOT</version>
+      <version>1.1.7</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
I was not able to build your project using maven. I had to add the jitpack repository and remove the -SNAPSHOT string from the vavi-commons version string. Once I changed these, mvn compile and mvn package worked perfectly. 